### PR TITLE
Fix Inlined comment with small formatting change

### DIFF
--- a/main.go
+++ b/main.go
@@ -376,6 +376,7 @@ func populateInlinedMemberComments(typePkgMap map[*types.Type]*apiPackage, c gen
 			return members, err
 		}
 		// Append the parent comments so the information is not lost
+		members[i].CommentLines = append([]string{""}, members[i].CommentLines...)
 		members[i].CommentLines = append(parentComments, members[i].CommentLines...)
 	}
 	return members, nil

--- a/template/members.tpl
+++ b/template/members.tpl
@@ -24,7 +24,7 @@
 
         {{ if isMemberInlined . }}
             <p>
-                (Inlined from {{ range (inlinedTypes .) }}<a href="{{ .Reference }}">{{ .Name }}</a>. Inlined comments are appended below.{{- end -}})
+                (Inlined from {{ range (inlinedTypes .) }}<a href="{{ .Reference }}">{{ .Name }}</a>. Inlined comments are appended in the following.{{- end -}})
             </p>
         {{ end }}
 


### PR DESCRIPTION
Separated parent comments into newlines, and fixed a grammatical request

![image](https://github.com/verrazzano/gen-crd-api-reference-docs/assets/49332517/5f927977-f397-4d75-9a16-7f0c0ffd432f)
